### PR TITLE
Fixed an error when creating a new P1Reader object with no parameters…

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,10 @@ var debug = require('./lib/debug');
 var config = require('./config/config.json');
 
 function P1Reader(options) {
+    if (typeof options !== 'object') {
+      options = {};
+    }
+
     debug.setDebugMode(options.debug);
 
     if (options.emulator) {


### PR DESCRIPTION
When using the example code from the README.md file, the following error occurs:
```
/root/p1/node_modules/p1-reader/main.js:15
    debug.setDebugMode(options.debug);
                              ^

TypeError: Cannot read property 'debug' of undefined
    at new P1Reader (/root/p1/node_modules/p1-reader/main.js:15:31)
    at Object.<anonymous> (/root/p1/app.js:2:16)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:383:7)
    at startup (bootstrap_node.js:149:9)
```
If no parameter was provided to `new P1Reader()`, the `options` parameter is undefined, which will result in an error when trying to read `options.debug`, since `debug` isn't a property of `undefined`. Asserting that `options` is an object will prevent this error.