### PR TITLE
Gas meters may be connected to ports 2, 3 or 4

### DIFF
--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -294,14 +294,23 @@ function parsePacket(packet) {
                  * So we make the assumption that a gas meter is attached to M-Bus 1.
                  */
                 case "0-1:24.1.0":
+                case "0-2:24.1.0":
+                case "0-3:24.1.0":
+                case "0-4:24.1.0":
                     parsedPacket.gas.deviceType = line.value;
                     break;
 
                 case "0-1:96.1.0":
+                case "0-2:96.1.0":
+                case "0-3:96.1.0":
+                case "0-4:96.1.0":
                     parsedPacket.gas.equipmentId = line.value;
                     break;
 
                 case "0-1:24.2.1":
+                case "0-2:24.2.1":
+                case "0-3:24.2.1":
+                case "0-4:24.2.1":
                     var hourlyReading = _parseHourlyReading(line.value);
 
                     parsedPacket.gas.timestamp = _parseTimestamp(hourlyReading.timestamp);
@@ -310,6 +319,9 @@ function parsePacket(packet) {
                     break;
 
                 case "0-1:24.4.0":
+                case "0-2:24.4.0":
+                case "0-3:24.4.0":
+                case "0-4:24.4.0":
                     parsedPacket.gas.valvePosition = line.value;
                     break;
 


### PR DESCRIPTION
The code assumes the gas meter is always connected to port 1. My gas meter was recently replaced and the replacement meter was connected to port 2. From what I can tell from the DSMR 4.0 spec, a gas meter can be connected to either port 1, 2, 3 or 4. Adding `case` lines for these ports fixed the `Unable to parse line: 0-2:24.1.0` error lines for me.