### PR TITLE
Upgraded serial port dependency from v4 to v6

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,15 +1,15 @@
 {
-    "serialPort": {
-        "baudrate": 115200,
-        "parity": "none",
-        "dataBits": 8,
-        "stopBits": 1
-    },
-    "startCharacter": "/",
-    "stopCharacter": "!",
-    "connectionSetupTimeout": 30000,
-    "debugRawDataFile": "debug-data-raw.log",
-    "debugParsedDataFile": "debug-data-parsed.log",
-    "emulatorIntervalInSeconds": 10,
-    "emulatorIntervalGasInSeconds": 3600
+  "serialPort": {
+    "baudRate": 115200,
+    "parity": "even",
+    "dataBits": 7,
+    "stopBits": 1
+  },
+  "startCharacter": "/",
+  "stopCharacter": "!",
+  "connectionSetupTimeout": 30000,
+  "debugRawDataFile": "debug-data-raw.log",
+  "debugParsedDataFile": "debug-data-parsed.log",
+  "emulatorIntervalInSeconds": 10,
+  "emulatorIntervalGasInSeconds": 3600
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/ruudverheijden/node-p1-reader.git"
   },
   "dependencies": {
-    "serialport": "4.0.7"
+    "serialport": "6.2.0"
   },
   "devDependencies": {
     "jasmine": "^2.5.3"


### PR DESCRIPTION
In order to make the Landys Gyr 350 work I had to change the config file. Serial port now uses the `baudRate` field instead of the `baudrate` field for configurations.