### PR TITLE
Parse Packet for the Belgian Gas meters

### DIFF
--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -139,6 +139,7 @@ function parsePacket(packet) {
 
             switch (line.obisCode) {
                 case "1-3:0.2.8":
+                case "0-0:96.1.4":
                     parsedPacket.version = line.value;
                     break;
 
@@ -320,6 +321,7 @@ function parsePacket(packet) {
                 case "0-2:96.1.0":
                 case "0-3:96.1.0":
                 case "0-4:96.1.0":
+                case "0-1:96.1.1":
                     parsedPacket.gas.equipmentId = line.value;
                     break;
 
@@ -332,6 +334,14 @@ function parsePacket(packet) {
                     parsedPacket.gas.timestamp = _parseTimestamp(hourlyReading.timestamp);
                     parsedPacket.gas.reading = parseFloat(hourlyReading.value);
                     parsedPacket.gas.unit = hourlyReading.unit;
+                    break;
+
+                case "0-1:24.2.3":
+                    
+                    const instantValue = line.value.substr(15,9);
+                    const instantUnit = line.value.substr(25,2);
+                    parsedPacket.gas.reading = parseFloat(instantValue);
+                    parsedPacket.gas.unit = instantUnit;
                     break;
 
                 case "0-1:24.4.0":


### PR DESCRIPTION
Allow parsing for Gas meters used by Belgian Utility Companies:
- Fluvius
- ORES
- RESA
- Sibelga