### PR TITLE
Add support for Obis codes `1-0:1.4.0`, `1-0:2.4.0`, `1-0:1.6.0`, `1-0:2.6.0`, `0-0:98.1.0`

### DIFF
--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -607,7 +607,7 @@ function _parseMaximumDemandLastMonths(value) {
                         value: parseFloat(split[i+2].split('*')[0]),
                         unit: split[i+2].split('*')[1],
                     }
-                    console.log("monthEntry", split[i], monthEntry);
+                    //console.log("monthEntry", split[i], monthEntry);
                     output.months.push(monthEntry);
                 } catch (ex){
                     // something is wrong here

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -585,13 +585,13 @@ function _parseMaximumDemandLastMonths(value) {
     const split = value.split(")(");
     if (split[0] && split[1]) {        
         let output = {
-            count: split[0].substring(10),
+            count: split[0].substring(9),
             months: []
         };
         console.log("_parseMaximumDemandLastMonths", split, "output", output);
 
         // Loop the buffer structure: timestamp)(timestamp)(value*unit)...
-        for (let i = 0; i <= split.length;) {
+        for (let i = 0; i < split.length;) {
             if(split[i] == "0-0:98.1.0(10" || split[i] == "1-0:1.6.0"){
                 i++;
                 continue;

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -410,7 +410,7 @@ function parsePacket(packet) {
                  * Demands mappings
                  */
                 case "1-0:1.4.0":
-                    //parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand = {};
+                    console.log("positiveActiveDemand", line);
                     parsePacket.electricity.demand = parsePacket.electricity.demand || {};
                     parsePacket.electricity.demand.currentDemandPeriod = parsePacket.electricity.demand.currentDemandPeriod || {};
                     parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand = {};
@@ -419,6 +419,9 @@ function parsePacket(packet) {
                     break;
                 
                 case "1-0:2.4.0":
+                    console.log("negativeActiveDemand", line);
+                    parsePacket.electricity.demand = parsePacket.electricity.demand || {};
+                    parsePacket.electricity.demand.currentDemandPeriod = parsePacket.electricity.demand.currentDemandPeriod || {};                    
                     parsePacket.electricity.demand.currentDemandPeriod.negativeActiveDemand = {};
                     parsePacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = parseFloat(line.value);
                     parsePacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = line.unit;

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -423,7 +423,7 @@ function parsePacket(packet) {
                     break;
 
                 /*
-                 * Demands mappings
+                 * Demands mappings, seen in belgian peak tarrif with meterType FLU5\253770234_A v50217.
                  */
                 case "1-0:1.4.0": // Positive active demand in a current demand period (A+) [kW]
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -3,7 +3,7 @@
  *
  * @param packet : P1 packet according to DSMR 2.2 or 4.0 specification
  */
-function parsePacket(packet) {
+function parsedPacket(packet) {
     const lines = packet.split(/\r\n|\n|\r/);
     let parsedPacket = {
         meterType: lines[0].substring(1),
@@ -410,21 +410,21 @@ function parsePacket(packet) {
                  * Demands mappings
                  */
                 case "1-0:1.4.0":
-                    console.log("positiveActiveDemand", line);
-                    parsePacket.electricity.demand = parsePacket.electricity.demand || {};
-                    parsePacket.electricity.demand.currentDemandPeriod = parsePacket.electricity.demand.currentDemandPeriod || {};
-                    parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand = {};
-                    parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = parseFloat(line.value);
-                    parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = line.unit;
+                    console.log("positiveActiveDemand", line, parsedPacket);
+                    parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
+                    parsedPacket.electricity.demand.currentDemandPeriod = parsedPacket.electricity.demand.currentDemandPeriod || {};
+                    parsedPacket.electricity.demand.currentDemandPeriod.positiveActiveDemand = {};
+                    parsedPacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = parseFloat(line.value);
+                    parsedPacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = line.unit;
                     break;
                 
                 case "1-0:2.4.0":
                     console.log("negativeActiveDemand", line);
-                    parsePacket.electricity.demand = parsePacket.electricity.demand || {};
-                    parsePacket.electricity.demand.currentDemandPeriod = parsePacket.electricity.demand.currentDemandPeriod || {};                    
-                    parsePacket.electricity.demand.currentDemandPeriod.negativeActiveDemand = {};
-                    parsePacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = parseFloat(line.value);
-                    parsePacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = line.unit;
+                    parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
+                    parsedPacket.electricity.demand.currentDemandPeriod = parsedPacket.electricity.demand.currentDemandPeriod || {};                    
+                    parsedPacket.electricity.demand.currentDemandPeriod.negativeActiveDemand = {};
+                    parsedPacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = parseFloat(line.value);
+                    parsedPacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = line.unit;
                     break;
 
                 /*
@@ -588,4 +588,4 @@ function _convertHexToAscii(string) {
     return output;
 }
 
-module.exports = parsePacket;
+module.exports = parsedPacket;

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -121,12 +121,24 @@ function parsedPacket(packet) {
                 }
             },
             demand: {
-                currentDemandPeriod: {
-                    positiveActiveDemand: {
+                positiveActiveDemand: {
+                    currentDemandPeriod: {
                         reading: null,
                         unit: null
                     },
-                    negativeActiveDemand: {
+                    maximumDemand: {
+                        timestamp: null,
+                        reading: null,
+                        unit: null
+                    }
+                },
+                negativeActiveDemand: {
+                    currentDemandPeriod: {
+                        reading: null,
+                        unit: null
+                    },
+                    maximumDemand: {
+                        timestamp: null,
                         reading: null,
                         unit: null
                     }
@@ -426,9 +438,13 @@ function parsedPacket(packet) {
                     break;
 
                 case "1-0:1.6.0": // Positive active maximum demand (A+) total [kW]
+                    
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
                     parsedPacket.electricity.demand.positiveActiveDemand = parsedPacket.electricity.demand.positiveActiveDemand || {};                    
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand = {};
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);
+                    console.log("parsing next block", lines[i], "to", lines[i].substring(15));
+                    line = _parseLine(lines[i].substring(15));
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(line.value);
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = line.unit;
                     break;

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -582,22 +582,20 @@ function _parsePowerFailureEventLog(value) {
  * 0-0:98.1.0(10)(1-0:1.6.0)(1-0:1.6.0)(230201000000W)(230129181500W)(05.380*kW)(230301000000W)(230210183000W)(05.769*kW)(230401000000S)(230312180000W)(06.309*kW)(230501000000S)(230410180000S)(05.310*kW)(230601000000S)(230506184500S)(04.369*kW)(230701000000S)(230610071500S)(05.253*kW)(230801000000S)(230727003000S)(04.364*kW)(230901000000S)(230824173000S)(04.689*kW)(231001000000S)(230923121500S)(04.278*kW)(231101000000W)(231014121500S)(05.416*kW)
  */
 function _parseMaximumDemandLastMonths(value) {
-    const split = value.split("0-0:98.1.0(");
-    console.log("_parseMaximumDemandLastMonths", split);
+    const split = value.split(/\((.+)?/); // Split only on first occurence of "("
+    if (split[0] && split[1]) {        
+        let output = {
+            count: split[1].substring(0, split[1].length - 1),
+            months: []
+        };
+        console.log("_parseMaximumDemandLastMonths", split, output);
 
-    let output = {
-        count: parseInt(split[0]) || 0,
-        months: []
-    };
-    console.log("_parseMaximumDemandLastMonths", split, output);
-
-    if (split[1]) {
-        const log = split[1].split(")(");
+        const log = value.split(")(");
         console.log("log", log);
 
         // Loop the buffer structure: timestamp)(timestamp)(value*unit)...
         for (let i = 0; i <= log.length;) {
-            if(log[i] == "1-0:1.6.0"){
+            if(log[i] == "0-0:98.1.0(10" || log[i] == "1-0:1.6.0"){
                 i++;
                 continue;
             }                

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -142,6 +142,10 @@ function parsePacket(packet) {
                         reading: null,
                         unit: null
                     }
+                },
+                maximumDemandLastMonths: {
+                    count: null,
+                    months: null
                 }
             }
         },

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -423,7 +423,7 @@ function parsePacket(packet) {
                     break;
 
                 /*
-                 * Demands mappings, seen in belgian peak tarrif with meterType FLU5\253770234_A v50217.
+                 * Demands mappings, seen in Belgian peak tariff with meterType FLU5\253770234_A v50217.
                  */
                 case "1-0:1.4.0": // Positive active demand in a current demand period (A+) [kW]
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -582,31 +582,28 @@ function _parsePowerFailureEventLog(value) {
  * 0-0:98.1.0(10)(1-0:1.6.0)(1-0:1.6.0)(230201000000W)(230129181500W)(05.380*kW)(230301000000W)(230210183000W)(05.769*kW)(230401000000S)(230312180000W)(06.309*kW)(230501000000S)(230410180000S)(05.310*kW)(230601000000S)(230506184500S)(04.369*kW)(230701000000S)(230610071500S)(05.253*kW)(230801000000S)(230727003000S)(04.364*kW)(230901000000S)(230824173000S)(04.689*kW)(231001000000S)(230923121500S)(04.278*kW)(231101000000W)(231014121500S)(05.416*kW)
  */
 function _parseMaximumDemandLastMonths(value) {
-    const split = value.split(/\((.+)?/); // Split only on first occurence of "("
+    const split = value.split(")(");
     if (split[0] && split[1]) {        
         let output = {
-            count: split[1].substring(0, split[1].length - 1),
+            count: split[0].substring(10),
             months: []
         };
-        console.log("_parseMaximumDemandLastMonths", split, output);
-
-        const log = value.split(")(");
-        console.log("log", log);
+        console.log("_parseMaximumDemandLastMonths", split, "output", output);
 
         // Loop the buffer structure: timestamp)(timestamp)(value*unit)...
-        for (let i = 0; i <= log.length;) {
-            if(log[i] == "0-0:98.1.0(10" || log[i] == "1-0:1.6.0"){
+        for (let i = 0; i <= split.length;) {
+            if(split[i] == "0-0:98.1.0(10" || split[i] == "1-0:1.6.0"){
                 i++;
                 continue;
             }                
             else {                
                 const monthEntry = {
-                    month: _parseTimestamp(log[i]),
-                    timestamp: _parseTimestamp(log[i+1]),
-                    value: parseFloat(log[i+2].split('*')[0]),
-                    unit: parseFloat(log[i+2].split('*')[1]),
+                    month: _parseTimestamp(split[i]),
+                    timestamp: _parseTimestamp(split[i+1]),
+                    value: parseFloat(split[i+2].split('*')[0]),
+                    unit: split[i+2].split('*')[1],
                 }
-                console.log("monthEntry", log[i], monthEntry);
+                console.log("monthEntry", split[i], monthEntry);
                 output.months.push(monthEntry);
                 i+=3;
             }

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -443,8 +443,8 @@ function parsedPacket(packet) {
                     parsedPacket.electricity.demand.positiveActiveDemand = parsedPacket.electricity.demand.positiveActiveDemand || {};                    
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand = {};
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);                    
-                    const subline = _parseLine(lines[i].substring(24));
-                    console.log("parsing next block", lines[i], "to", lines[i].substring(24), "subline", subline);
+                    const subline = _parseLine(line.obisCode + lines[i].substring(24));
+                    console.log(line, "parsing next block", lines[i], "to", lines[i].substring(24), "subline", subline);
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(subline.value);
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = subline.unit;
                     break;

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -442,9 +442,9 @@ function parsedPacket(packet) {
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
                     parsedPacket.electricity.demand.positiveActiveDemand = parsedPacket.electricity.demand.positiveActiveDemand || {};                    
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand = {};
-                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);
-                    console.log("parsing next block", lines[i], "to", lines[i].substring(24));
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);                    
                     const subline = _parseLine(lines[i].substring(24));
+                    console.log("parsing next block", lines[i], "to", lines[i].substring(24), "subline", subline);
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(subline.value);
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = subline.unit;
                     break;

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -409,24 +409,37 @@ function parsedPacket(packet) {
                 /*
                  * Demands mappings
                  */
-                case "1-0:1.4.0":
-                    console.log("positiveActiveDemand", line, parsedPacket);
+                case "1-0:1.4.0": // Positive active demand in a current demand period (A+) [kW]
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
-                    parsedPacket.electricity.demand.currentDemandPeriod = parsedPacket.electricity.demand.currentDemandPeriod || {};
-                    parsedPacket.electricity.demand.currentDemandPeriod.positiveActiveDemand = {};
-                    parsedPacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = parseFloat(line.value);
-                    parsedPacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = line.unit;
+                    parsedPacket.electricity.demand.positiveActiveDemand = parsedPacket.electricity.demand.positiveActiveDemand || {};
+                    parsedPacket.electricity.demand.positiveActiveDemand.currentDemandPeriod = {};
+                    parsedPacket.electricity.demand.positiveActiveDemand.currentDemandPeriod.value = parseFloat(line.value);
+                    parsedPacket.electricity.demand.positiveActiveDemand.currentDemandPeriod.unit = line.unit;
                     break;
                 
-                case "1-0:2.4.0":
-                    console.log("negativeActiveDemand", line);
+                case "1-0:2.4.0": // Negative active demand in a current demand period (A-) [kW]
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
-                    parsedPacket.electricity.demand.currentDemandPeriod = parsedPacket.electricity.demand.currentDemandPeriod || {};                    
-                    parsedPacket.electricity.demand.currentDemandPeriod.negativeActiveDemand = {};
-                    parsedPacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = parseFloat(line.value);
-                    parsedPacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = line.unit;
+                    parsedPacket.electricity.demand.negativeActiveDemand = parsedPacket.electricity.demand.negativeActiveDemand || {};                    
+                    parsedPacket.electricity.demand.negativeActiveDemand.currentDemandPeriod = {};
+                    parsedPacket.electricity.demand.negativeActiveDemand.currentDemandPeriod.value = parseFloat(line.value);
+                    parsedPacket.electricity.demand.negativeActiveDemand.currentDemandPeriod.unit = line.unit;
                     break;
 
+                case "1-0:1.6.0": // Positive active maximum demand (A+) total [kW]
+                    parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
+                    parsedPacket.electricity.demand.positiveActiveDemand = parsedPacket.electricity.demand.positiveActiveDemand || {};                    
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand = {};
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(line.value);
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = line.unit;
+                    break;
+                case "1-0:2.6.0": // Negative active maximum demand (A-) total [kW]
+                    parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
+                    parsedPacket.electricity.demand.negativeActiveDemand = parsedPacket.electricity.demand.negativeActiveDemand || {};                    
+                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand = {};
+                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.value = parseFloat(line.value);
+                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.unit = line.unit;
+                    break;
+    
                 /*
                  * Handling anything not matched so far
                  */

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -584,13 +584,13 @@ function _parsePowerFailureEventLog(value) {
  * 0-0:98.1.0(10)(1-0:1.6.0)(1-0:1.6.0)(230201000000W)(230129181500W)(05.380*kW)(230301000000W)(230210183000W)(05.769*kW)(230401000000S)(230312180000W)(06.309*kW)(230501000000S)(230410180000S)(05.310*kW)(230601000000S)(230506184500S)(04.369*kW)(230701000000S)(230610071500S)(05.253*kW)(230801000000S)(230727003000S)(04.364*kW)(230901000000S)(230824173000S)(04.689*kW)(231001000000S)(230923121500S)(04.278*kW)(231101000000W)(231014121500S)(05.416*kW)
  */
 function _parseMaximumDemandLastMonths(value) {
-    const split = value.split(")(");
+    const split = value.substring(0, value.length-1).split(")(");
     if (split[0] && split[1]) {        
         let output = {
-            count: split[0].substring(9),
+            count: parseInt(split[0].substring(11)),
             months: []
-        };
-        console.log("_parseMaximumDemandLastMonths", split, "output", output);
+        };        
+        //console.log("_parseMaximumDemandLastMonths", split, "output", output);
 
         // Loop the buffer structure: timestamp)(timestamp)(value*unit)...
         for (let i = 0; i < split.length;) {
@@ -598,15 +598,20 @@ function _parseMaximumDemandLastMonths(value) {
                 i++;
                 continue;
             }                
-            else {                
-                const monthEntry = {
-                    month: _parseTimestamp(split[i]),
-                    timestamp: _parseTimestamp(split[i+1]),
-                    value: parseFloat(split[i+2].split('*')[0]),
-                    unit: split[i+2].split('*')[1],
+            else {
+                try{
+                                 
+                    const monthEntry = {
+                        month: _parseTimestamp(split[i]),
+                        timestamp: _parseTimestamp(split[i+1]),
+                        value: parseFloat(split[i+2].split('*')[0]),
+                        unit: split[i+2].split('*')[1],
+                    }
+                    console.log("monthEntry", split[i], monthEntry);
+                    output.months.push(monthEntry);
+                } catch (ex){
+                    // something is wrong here
                 }
-                console.log("monthEntry", split[i], monthEntry);
-                output.months.push(monthEntry);
                 i+=3;
             }
         }

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -441,8 +441,7 @@ function parsePacket(packet) {
                     parsedPacket.electricity.demand.negativeActiveDemand.currentDemandPeriod.unit = line.unit;
                     break;
 
-                case "1-0:1.6.0": // Positive active maximum demand (A+) total [kW]
-                    
+                case "1-0:1.6.0": // Positive active maximum demand (A+) total [kW]                    
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
                     parsedPacket.electricity.demand.positiveActiveDemand = parsedPacket.electricity.demand.positiveActiveDemand || {};                    
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand = {};

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -460,9 +460,11 @@ function parsedPacket(packet) {
                 
                 case "0-0:98.1.0": // Maximum demand - Active energy import of the last 13 months
                     const mdaeil13m = _parseMaximumDemandLastMonths(lines[i]);
-                    parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
-                    parsedPacket.electricity.demand.maximumDemandLastMonths = parsedPacket.electricity.demand.maximumDemandLastMonths || {};
-                    parsedPacket.electricity.demand.maximumDemandLastMonths = mdaeil13m;
+                    if(mdaeil13m != -1){
+                        parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
+                        parsedPacket.electricity.demand.maximumDemandLastMonths = parsedPacket.electricity.demand.maximumDemandLastMonths || {};
+                        parsedPacket.electricity.demand.maximumDemandLastMonths = mdaeil13m;
+                    }
                     break;
     
                 /*
@@ -608,8 +610,13 @@ function _parseMaximumDemandLastMonths(value) {
                 i+=3;
             }
         }
+        return output;
     }
-    return output;
+    else
+    {
+        return -1;
+    }
+    
 }
 
 /**

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -119,6 +119,18 @@ function parsePacket(packet) {
                         }
                     }
                 }
+            },
+            demand: {
+                currentDemandPeriod: {
+                    positiveActiveDemand: {
+                        reading: null,
+                        unit: null
+                    },
+                    negativeActiveDemand: {
+                        reading: null,
+                        unit: null
+                    }
+                }
             }
         },
         gas: {
@@ -392,6 +404,21 @@ function parsePacket(packet) {
                     parsedPacket.electricity.fuseThreshold = {};
                     parsedPacket.electricity.fuseThreshold.value = parseFloat(line.value);
                     parsedPacket.electricity.fuseThreshold.unit = 'A';
+                    break;
+
+                /*
+                 * Demands mappings
+                 */
+                case "1-0:1.4.0":
+                    parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand = {};
+                    parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = parseFloat(line.value);
+                    parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = line.unit;
+                    break;
+                
+                case "1-0:2.4.0":
+                    parsePacket.electricity.demand.currentDemandPeriod.negativeActiveDemand = {};
+                    parsePacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = parseFloat(line.value);
+                    parsePacket.electricity.demand.currentDemandPeriod.negativeActiveDemand.value = line.unit;
                     break;
 
                 /*

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -429,7 +429,7 @@ function parsePacket(packet) {
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
                     parsedPacket.electricity.demand.positiveActiveDemand = parsedPacket.electricity.demand.positiveActiveDemand || {};
                     parsedPacket.electricity.demand.positiveActiveDemand.currentDemandPeriod = {};
-                    parsedPacket.electricity.demand.positiveActiveDemand.currentDemandPeriod.value = parseFloat(line.value);
+                    parsedPacket.electricity.demand.positiveActiveDemand.currentDemandPeriod.reading = parseFloat(line.value);
                     parsedPacket.electricity.demand.positiveActiveDemand.currentDemandPeriod.unit = line.unit;
                     break;
                 
@@ -437,7 +437,7 @@ function parsePacket(packet) {
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
                     parsedPacket.electricity.demand.negativeActiveDemand = parsedPacket.electricity.demand.negativeActiveDemand || {};                    
                     parsedPacket.electricity.demand.negativeActiveDemand.currentDemandPeriod = {};
-                    parsedPacket.electricity.demand.negativeActiveDemand.currentDemandPeriod.value = parseFloat(line.value);
+                    parsedPacket.electricity.demand.negativeActiveDemand.currentDemandPeriod.reading = parseFloat(line.value);
                     parsedPacket.electricity.demand.negativeActiveDemand.currentDemandPeriod.unit = line.unit;
                     break;
 
@@ -447,7 +447,7 @@ function parsePacket(packet) {
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand = {};
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);                    
                     const padmdVal = _parseLine(line.obisCode + lines[i].substring(24));
-                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(padmdVal.value);
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.reading = parseFloat(padmdVal.value);
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = padmdVal.unit;
                     break;
                 
@@ -457,7 +457,7 @@ function parsePacket(packet) {
                     parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand = {};
                     parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);
                     const nadmdVal = _parseLine(line.obisCode + lines[i].substring(24));
-                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.value = parseFloat(nadmdVal.value);
+                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.reading = parseFloat(nadmdVal.value);
                     parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.unit = nadmdVal.unit;
                     break;
                 

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -410,6 +410,9 @@ function parsePacket(packet) {
                  * Demands mappings
                  */
                 case "1-0:1.4.0":
+                    //parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand = {};
+                    parsePacket.electricity.demand = parsePacket.electricity.demand || {};
+                    parsePacket.electricity.demand.currentDemandPeriod = parsePacket.electricity.demand.currentDemandPeriod || {};
                     parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand = {};
                     parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = parseFloat(line.value);
                     parsePacket.electricity.demand.currentDemandPeriod.positiveActiveDemand.value = line.unit;

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -3,7 +3,7 @@
  *
  * @param packet : P1 packet according to DSMR 2.2 or 4.0 specification
  */
-function parsedPacket(packet) {
+function parsePacket(packet) {
     const lines = packet.split(/\r\n|\n|\r/);
     let parsedPacket = {
         meterType: lines[0].substring(1),
@@ -674,4 +674,4 @@ function _convertHexToAscii(string) {
     return output;
 }
 
-module.exports = parsedPacket;
+module.exports = parsePacket;

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -443,17 +443,26 @@ function parsedPacket(packet) {
                     parsedPacket.electricity.demand.positiveActiveDemand = parsedPacket.electricity.demand.positiveActiveDemand || {};                    
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand = {};
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);                    
-                    const subline = _parseLine(line.obisCode + lines[i].substring(24));
-                    console.log(line, "parsing next block", lines[i], "to", lines[i].substring(24), "subline", subline);
-                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(subline.value);
-                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = subline.unit;
+                    const padmdVal = _parseLine(line.obisCode + lines[i].substring(24));
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(padmdVal.value);
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = padmdVal.unit;
                     break;
-                case "1-0:2.6.0": // Negative active maximum demand (A-) total [kW]
+                
+                    case "1-0:2.6.0": // Negative active maximum demand (A-) total [kW]
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
                     parsedPacket.electricity.demand.negativeActiveDemand = parsedPacket.electricity.demand.negativeActiveDemand || {};                    
                     parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand = {};
-                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.value = parseFloat(line.value);
-                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.unit = line.unit;
+                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);
+                    const nadmdVal = _parseLine(line.obisCode + lines[i].substring(24));
+                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.value = parseFloat(nadmdVal.value);
+                    parsedPacket.electricity.demand.negativeActiveDemand.maximumDemand.unit = nadmdVal.unit;
+                    break;
+                
+                case "0-0:98.1.0": // Maximum demand - Active energy import of the last 13 months
+                    const mdaeil13m = _parseMaximumDemandLastMonths(lines[i]);
+                    parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};
+                    parsedPacket.electricity.demand.maximumDemandLastMonths = parsedPacket.electricity.demand.maximumDemandLastMonths || {};
+                    parsedPacket.electricity.demand.maximumDemandLastMonths = mdaeil13m;
                     break;
     
                 /*
@@ -564,6 +573,47 @@ function _parsePowerFailureEventLog(value) {
         }
     }
 
+    return output;
+}
+
+/**
+ * 
+ * @param value : the capture buffer. Example: 
+ * 0-0:98.1.0(10)(1-0:1.6.0)(1-0:1.6.0)(230201000000W)(230129181500W)(05.380*kW)(230301000000W)(230210183000W)(05.769*kW)(230401000000S)(230312180000W)(06.309*kW)(230501000000S)(230410180000S)(05.310*kW)(230601000000S)(230506184500S)(04.369*kW)(230701000000S)(230610071500S)(05.253*kW)(230801000000S)(230727003000S)(04.364*kW)(230901000000S)(230824173000S)(04.689*kW)(231001000000S)(230923121500S)(04.278*kW)(231101000000W)(231014121500S)(05.416*kW)
+ */
+function _parseMaximumDemandLastMonths(value) {
+    const split = value.split("0-0:98.1.0(");
+    console.log("_parseMaximumDemandLastMonths", split);
+
+    let output = {
+        count: parseInt(split[0]) || 0,
+        months: []
+    };
+    console.log("_parseMaximumDemandLastMonths", split, output);
+
+    if (split[1]) {
+        const log = split[1].split(")(");
+        console.log("log", log);
+
+        // Loop the buffer structure: timestamp)(timestamp)(value*unit)...
+        for (let i = 0; i <= log.length;) {
+            if(log[i] == "1-0:1.6.0"){
+                i++;
+                continue;
+            }                
+            else {                
+                const monthEntry = {
+                    month: _parseTimestamp(log[i]),
+                    timestamp: _parseTimestamp(log[i+1]),
+                    value: parseFloat(log[i+2].split('*')[0]),
+                    unit: parseFloat(log[i+2].split('*')[1]),
+                }
+                console.log("monthEntry", log[i], monthEntry);
+                output.months.push(monthEntry);
+                i+=3;
+            }
+        }
+    }
     return output;
 }
 

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -444,9 +444,9 @@ function parsedPacket(packet) {
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand = {};
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);
                     console.log("parsing next block", lines[i], "to", lines[i].substring(15));
-                    line = _parseLine(lines[i].substring(15));
-                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(line.value);
-                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = line.unit;
+                    const subline = _parseLine(lines[i].substring(15));
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(subline.value);
+                    parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = subline.unit;
                     break;
                 case "1-0:2.6.0": // Negative active maximum demand (A-) total [kW]
                     parsedPacket.electricity.demand = parsedPacket.electricity.demand || {};

--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -443,8 +443,8 @@ function parsedPacket(packet) {
                     parsedPacket.electricity.demand.positiveActiveDemand = parsedPacket.electricity.demand.positiveActiveDemand || {};                    
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand = {};
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.timestamp = _parseTimestamp(line.value);
-                    console.log("parsing next block", lines[i], "to", lines[i].substring(15));
-                    const subline = _parseLine(lines[i].substring(15));
+                    console.log("parsing next block", lines[i], "to", lines[i].substring(24));
+                    const subline = _parseLine(lines[i].substring(24));
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.value = parseFloat(subline.value);
                     parsedPacket.electricity.demand.positiveActiveDemand.maximumDemand.unit = subline.unit;
                     break;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/ruudverheijden/node-p1-reader.git"
   },
   "dependencies": {
-    "serialport": "^12.0.0"
+    "serialport": "^8.0.8"
   },
   "devDependencies": {
     "jasmine": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p1-reader",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Node.js package for reading and parsing data from the P1 port of a Smart Meter",
   "main": "main.js",
   "author": "Ruud Verheijden",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/ruudverheijden/node-p1-reader.git"
   },
   "dependencies": {
-    "serialport": "^8.0.8"
+    "serialport": "^12.0.0"
   },
   "devDependencies": {
     "jasmine": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p1-reader",
-  "version": "2.0.5-b",
+  "version": "2.0.5",
   "description": "Node.js package for reading and parsing data from the P1 port of a Smart Meter",
   "main": "main.js",
   "author": "Ruud Verheijden",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p1-reader",
-  "version": "2.0.5",
+  "version": "2.0.5-b",
   "description": "Node.js package for reading and parsing data from the P1 port of a Smart Meter",
   "main": "main.js",
   "author": "Ruud Verheijden",

--- a/spec/parsePacketSpec.js
+++ b/spec/parsePacketSpec.js
@@ -1601,7 +1601,8 @@ describe("parsePacket", function() {
 
         expect(parsedPacket).toEqual(expectedOutputObject);
     });
-
+ 
+    // Test demands code seen on belgian meters (peak tariff)
     it("should be able to parse a complete DSMR5.0 packet with demands", function() {
         const packet = "/FLU5\253770234_A\r\n" +
         "\r\n" +

--- a/spec/parsePacketSpec.js
+++ b/spec/parsePacketSpec.js
@@ -1602,4 +1602,221 @@ describe("parsePacket", function() {
         expect(parsedPacket).toEqual(expectedOutputObject);
     });
 
+    it("should be able to parse a complete DSMR5.0 packet with demands", function() {
+        const packet = "/FLU5\253770234_A\r\n" +
+        "\r\n" +
+        "1-3:0.2.8(50217)\r\n" +
+        "0-0:1.0.0(101209113020W)\r\n" +
+        "0-0:96.1.1(4B384547303034303436333935353037)\r\n" +
+        "1-0:1.8.1(123456.789*kWh)\r\n" +
+        "1-0:1.8.2(123456.789*kWh)\r\n" +
+        "1-0:2.8.1(123456.789*kWh)\r\n" +
+        "1-0:2.8.2(123456.789*kWh)\r\n" +
+        "0-0:96.14.0(0002)\r\n" +
+        "1-0:1.7.0(01.193*kW)\r\n" +
+        "1-0:2.7.0(00.000*kW)\r\n" +
+        "0-0:96.7.21(00004)\r\n" +
+        "0-0:96.7.9(00002)\r\n" +
+        "1-0:99.97.0(2)(0-0:96.7.19)(101208152415W)(0000000240*s)(101208151004W)(0000000301*s)\r\n" +
+        "1-0:32.32.0(00002)\r\n" +
+        "1-0:52.32.0(00001)\r\n" +
+        "1-0:72.32.0(00000)\r\n" +
+        "1-0:32.36.0(00000)\r\n" +
+        "1-0:52.36.0(00003)\r\n" +
+        "1-0:72.36.0(00000)\r\n" +
+        "0-0:96.13.0(303132333435363738393A3B3C3D3E3F303132333435363738393A3B3C3D3E3F303132333435363738393A3B3C3D3E3F303132333435363738393A3B3C3D3E3F303132333435363738393A3B3C3D3E3F)\r\n" +
+        "1-0:32.7.0(220.1*V)\r\n" +
+        "1-0:52.7.0(220.2*V)\r\n" +
+        "1-0:72.7.0(220.3*V)\r\n" +
+        "1-0:31.7.0(001*A)\r\n" +
+        "1-0:51.7.0(002*A)\r\n" +
+        "1-0:71.7.0(003*A)\r\n" +
+        "1-0:21.7.0(01.111*kW)\r\n" +
+        "1-0:41.7.0(02.222*kW)\r\n" +
+        "1-0:61.7.0(03.333*kW)\r\n" +
+        "1-0:22.7.0(04.444*kW)\r\n" +
+        "1-0:42.7.0(05.555*kW)\r\n" +
+        "1-0:62.7.0(06.666*kW)\r\n" +
+        "0-1:24.1.0(003)\r\n" +
+        "0-1:96.1.0(3232323241424344313233343536373839)\r\n" +
+        "0-1:24.2.1(101209112500W)(12785.123*m3)\r\n" +
+        "1-0:1.4.0(00.242*kW)\r\n" +
+        "1-0:1.6.0(231107174500W)(07.677*kW)\r\n" + 
+        "0-0:98.1.0(10)(1-0:1.6.0)(1-0:1.6.0)(230201000000W)(230129181500W)(05.380*kW)(230301000000W)(230210183000W)(05.769*kW)(230401000000S)(230312180000W)(06.309*kW)(230501000000S)(230410180000S)(05.310*kW)(230601000000S)(230506184500S)(04.369*kW)(230701000000S)(230610071500S)(05.253*kW)(230801000000S)(230727003000S)(04.364*kW)(230901000000S)(230824173000S)(04.689*kW)(231001000000S)(230923121500S)(04.278*kW)(231101000000W)(231014121500S)(05.416*kW)";
+
+        const parsedPacket = parsePacket(packet);
+
+        const expectedOutputObject = {
+            "meterType": "FLU5\253770234_A",
+            "version": "50217",
+            "timestamp": "2010-12-09T11:30:20.000Z",
+            "equipmentId": "4B384547303034303436333935353037",
+            "textMessage": {
+                "codes": null,
+                "message": "0123456789:;<=>?0123456789:;<=>?0123456789:;<=>?0123456789:;<=>?0123456789:;<=>?"
+            },
+            "electricity": {
+                "received": {
+                    "tariff1": {
+                        "reading": 123456.789,
+                        "unit": "kWh"
+                    },
+                    "tariff2": {
+                        "reading": 123456.789,
+                        "unit": "kWh"
+                    },
+                    "actual": {
+                        "reading": 1.193,
+                        "unit": "kW"
+                    }
+                },
+                "delivered": {
+                    "tariff1": {
+                        "reading": 123456.789,
+                        "unit": "kWh"
+                    },
+                    "tariff2": {
+                        "reading": 123456.789,
+                        "unit": "kWh"
+                    },
+                    "actual": {
+                        "reading": 0,
+                        "unit": "kW"
+                    }
+                },
+                "tariffIndicator": 2,
+                "threshold": null,
+                "fuseThreshold": null,
+                "switchPosition": null,
+                "numberOfPowerFailures": 4,
+                "numberOfLongPowerFailures": 2,
+                "longPowerFailureLog": {
+                    "count": 2,
+                    "log": [
+                        {
+                            "startOfFailure": "2010-12-08T15:20:15.000Z",
+                            "endOfFailure": "2010-12-08T15:24:15.000Z",
+                            "duration": 240,
+                            "unit": "s"
+                        },
+                        {
+                            "startOfFailure": "2010-12-08T15:05:03.000Z",
+                            "endOfFailure": "2010-12-08T15:10:04.000Z",
+                            "duration": 301,
+                            "unit": "s"
+                        }
+                    ]
+                },
+                "voltageSags": {
+                    "L1": 2,
+                    "L2": 1,
+                    "L3": 0
+                },
+                "voltageSwell": {
+                    "L1": 0,
+                    "L2": 3,
+                    "L3": 0
+                },
+                "instantaneous": {
+                    "current": {
+                        "L1": {
+                            "reading": 1,
+                            "unit": "A"
+                        },
+                        "L2": {
+                            "reading": 2,
+                            "unit": "A"
+                        },
+                        "L3": {
+                            "reading": 3,
+                            "unit": "A"
+                        }
+                    },
+                    "voltage": {
+                        "L1": {
+                            "reading": 220,
+                            "unit": "V"
+                        },
+                        "L2": {
+                            "reading": 220,
+                            "unit": "V"
+                        },
+                        "L3": {
+                            "reading": 220,
+                            "unit": "V"
+                        }
+                    },
+                    "power": {
+                        "positive": {
+                            "L1": {
+                                "reading": 1.111,
+                                "unit": "kW"
+                            },
+                            "L2": {
+                                "reading": 2.222,
+                                "unit": "kW"
+                            },
+                            "L3": {
+                                "reading": 3.333,
+                                "unit": "kW"
+                            }
+                        },
+                        "negative": {
+                            "L1": {
+                                "reading": 4.444,
+                                "unit": "kW"
+                            },
+                            "L2": {
+                                "reading": 5.555,
+                                "unit": "kW"
+                            },
+                            "L3": {
+                                "reading": 6.666,
+                                "unit": "kW"
+                            }
+                        }
+                    }
+                },
+                demand: {
+                    positiveActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: "kW"
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: "kW"
+                        }
+                    },
+                    negativeActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: "kW"
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    maximumDemandLastMonths: {
+                        count: 10,
+                        months: null
+                    }
+                }
+            },
+            "gas": {
+                "deviceType": "003",
+                "equipmentId": "3232323241424344313233343536373839",
+                "timestamp": "2010-12-09T11:25:00.000Z",
+                "reading": 12785.123,
+                "unit": "m3",
+                "valvePosition": null
+            }
+        };
+
+        expect(parsedPacket).toEqual(expectedOutputObject);
+    });
+
 });

--- a/spec/parsePacketSpec.js
+++ b/spec/parsePacketSpec.js
@@ -1802,7 +1802,68 @@ describe("parsePacket", function() {
                     },
                     maximumDemandLastMonths: {
                         count: 10,
-                        months: null
+                        months: [
+                            {
+                                "month": "2023-02-01T00:00:00.000Z",
+                                "timestamp": "2023-01-29T18:15:00.000Z",
+                                "value": 5.38,
+                                "unit": "kW"
+                            },
+                            {
+                                "month": "2023-03-01T00:00:00.000Z",
+                                "timestamp": "2023-02-10T18:30:00.000Z",
+                                "value": 5.769,
+                                "unit": "kW"
+                            },
+                            {
+                                "month": "2023-04-01T00:00:00.000Z",
+                                "timestamp": "2023-03-12T18:00:00.000Z",
+                                "value": 6.309,
+                                "unit": "kW"
+                            },
+                            {
+                                "month": "2023-05-01T00:00:00.000Z",
+                                "timestamp": "2023-04-10T18:00:00.000Z",
+                                "value": 5.31,
+                                "unit": "kW"
+                            },
+                            {
+                                "month": "2023-06-01T00:00:00.000Z",
+                                "timestamp": "2023-05-06T18:45:00.000Z",
+                                "value": 4.369,
+                                "unit": "kW"
+                            },
+                            {
+                                "month": "2023-07-01T00:00:00.000Z",
+                                "timestamp": "2023-06-10T07:15:00.000Z",
+                                "value": 5.253,
+                                "unit": "kW"
+                            },
+                            {
+                                "month": "2023-08-01T00:00:00.000Z",
+                                "timestamp": "2023-07-27T00:30:00.000Z",
+                                "value": 4.364,
+                                "unit": "kW"
+                            },
+                            {
+                                "month": "2023-09-01T00:00:00.000Z",
+                                "timestamp": "2023-08-24T17:30:00.000Z",
+                                "value": 4.689,
+                                "unit": "kW"
+                            },
+                            {
+                                "month": "2023-10-01T00:00:00.000Z",
+                                "timestamp": "2023-09-23T12:15:00.000Z",
+                                "value": 4.278,
+                                "unit": "kW"
+                            },
+                            {
+                                "month": "2023-11-01T00:00:00.000Z",
+                                "timestamp": "2023-10-14T12:15:00.000Z",
+                                "value": 5.416,
+                                "unit": "kW"
+                            }
+                        ]
                     }
                 }
             },

--- a/spec/parsePacketSpec.js
+++ b/spec/parsePacketSpec.js
@@ -127,6 +127,34 @@ describe("parsePacket", function() {
                             }
                         }
                     }
+                },
+                demand: {
+                    positiveActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    negativeActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    maximumDemandLastMonths: {
+                        count: null,
+                        months: null
+                    }
                 }
             },
             gas: {
@@ -320,6 +348,34 @@ describe("parsePacket", function() {
                             }
                         }
                     }
+                },
+                demand: {
+                    positiveActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    negativeActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    maximumDemandLastMonths: {
+                        count: null,
+                        months: null
+                    }
                 }
             },
             "gas": {
@@ -497,6 +553,34 @@ describe("parsePacket", function() {
                             }
                         }
                     }
+                },
+                demand: {
+                    positiveActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    negativeActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    maximumDemandLastMonths: {
+                        count: null,
+                        months: null
+                    }
                 }
             },
             "gas": {
@@ -648,6 +732,34 @@ describe("parsePacket", function() {
                                 "unit": null
                             }
                         }
+                    }
+                },
+                demand: {
+                    positiveActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    negativeActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    maximumDemandLastMonths: {
+                        count: null,
+                        months: null
                     }
                 }
             },
@@ -801,6 +913,34 @@ describe("parsePacket", function() {
                                 "unit": null
                             }
                         }
+                    }
+                },
+                demand: {
+                    positiveActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    negativeActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    maximumDemandLastMonths: {
+                        count: null,
+                        months: null
                     }
                 }
             },
@@ -991,6 +1131,34 @@ describe("parsePacket", function() {
                             }
                         }
                     }
+                },
+                demand: {
+                    positiveActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    negativeActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    maximumDemandLastMonths: {
+                        count: null,
+                        months: null
+                    }
                 }
             },
             "gas": {
@@ -1177,6 +1345,34 @@ describe("parsePacket", function() {
                             }
                         }
                     }
+                },
+                demand: {
+                    positiveActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    negativeActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    maximumDemandLastMonths: {
+                        count: null,
+                        months: null
+                    }
                 }
             },
             "gas": {
@@ -1362,6 +1558,34 @@ describe("parsePacket", function() {
                                 "unit": "kW"
                             }
                         }
+                    }
+                },
+                demand: {
+                    positiveActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    negativeActiveDemand: {
+                        currentDemandPeriod: {
+                            reading: null,
+                            unit: null
+                        },
+                        maximumDemand: {
+                            timestamp: null,
+                            reading: null,
+                            unit: null
+                        }
+                    },
+                    maximumDemandLastMonths: {
+                        count: null,
+                        months: null
                     }
                 }
             },

--- a/spec/parsePacketSpec.js
+++ b/spec/parsePacketSpec.js
@@ -1780,19 +1780,19 @@ describe("parsePacket", function() {
                 demand: {
                     positiveActiveDemand: {
                         currentDemandPeriod: {
-                            reading: null,
+                            reading: 0.242,
                             unit: "kW"
                         },
                         maximumDemand: {
-                            timestamp: null,
-                            reading: null,
+                            timestamp: '2023-11-07T17:45:00.000Z',
+                            reading: 7.677,
                             unit: "kW"
                         }
                     },
                     negativeActiveDemand: {
                         currentDemandPeriod: {
                             reading: null,
-                            unit: "kW"
+                            unit: null
                         },
                         maximumDemand: {
                             timestamp: null,

--- a/spec/parsePacketSpec.js
+++ b/spec/parsePacketSpec.js
@@ -1602,7 +1602,7 @@ describe("parsePacket", function() {
         expect(parsedPacket).toEqual(expectedOutputObject);
     });
  
-    // Test demands code seen on belgian meters (peak tariff)
+    // Test demands code seen on Belgian meters (peak tariff)
     it("should be able to parse a complete DSMR5.0 packet with demands", function() {
         const packet = "/FLU5\253770234_A\r\n" +
         "\r\n" +


### PR DESCRIPTION
Add support for the following Obis codes:
  - `1-0:1.4.0`: Positive active demand in a current demand period (A+) [kW], 
  - `1-0:2.4.0`: Negative active demand in a current demand period (A-) [kW], 
  - `1-0:1.6.0`: Positive active maximum demand (A+) total [kW], 
  - `1-0:2.6.0`: Negative active maximum demand (A-) total [kW], 
  - `0-0:98.1.0`: Maximum demand - Active energy import of the last 13 months

Seen with Belgian peak tariff with meterType FLU5\253770234_A v50217.