### PR TITLE
Fix emulator; it lacks a pipe function

### DIFF
--- a/lib/emulateSerialport.js
+++ b/lib/emulateSerialport.js
@@ -22,6 +22,13 @@ let intervalGas = config.emulatorIntervalGasInSeconds * 1000;
 function EmulateSerialport(path, options, callback) {
     const constructor = this;
 
+    this.pipe = function (target) {
+        constructor.on('data', data => {
+            target.write(data);
+        });
+        return target;
+    };
+
     EventEmitter.call(this);
 
     // Delay the opening of a connection so the listeners have time to initiate before the event is emitted


### PR DESCRIPTION
The emulator is currently broken as it lacks a `pipe` function. Adding a simple `pipe` implementation to make it work again.